### PR TITLE
Twenty more bits of c o l o u r

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -4,7 +4,7 @@ tests: True
 source-repository-package
   type: git
   location: https://github.com/fused-effects/fused-effects-parser.git
-  tag: 90b0b6bd9afddd48a1208f7d09d8a81f1ced9793
+  tag: aa3c6349dad5e359d7fecc5403c1c183dbd2ca1c
 
 source-repository-package
   type: git

--- a/facet.cabal
+++ b/facet.cabal
@@ -72,7 +72,6 @@ library
     , optparse-applicative
     , parsers
     , prettyprinter
-    , prettyprinter-ansi-terminal
     , selective
     , semialign
     , silkscreen

--- a/facet.cabal
+++ b/facet.cabal
@@ -59,6 +59,7 @@ library
     Paths_facet
     Text.Parser.Position
   build-depends:
+    , ansi-terminal
     , base ^>= 4.14
     , charset
     , containers

--- a/facet.cabal
+++ b/facet.cabal
@@ -62,6 +62,7 @@ library
     , ansi-terminal
     , base ^>= 4.14
     , charset
+    , colour
     , containers
     , fused-effects
     , fused-effects-lens

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -37,7 +37,6 @@ module Facet.Elab
   -- * Modules
 , elabModule
   -- * Errors
-, ErrDoc
 , Err(..)
 , Reason(..)
 ) where
@@ -64,8 +63,6 @@ import           Facet.Stack hiding ((!?))
 import qualified Facet.Surface as S
 import           Facet.Syntax
 import           GHC.Stack
-import           Prettyprinter (Doc)
-import           Prettyprinter.Render.Terminal (AnsiStyle)
 import           Text.Parser.Position (Spanned)
 
 type Type = Value
@@ -517,8 +514,6 @@ withSpan k (s, a) = setSpan s (k a)
 withSpan' :: Has (Reader Span) sig m => (a -> b -> m c) -> (Span, a) -> b -> m c
 withSpan' k (s, a) b = setSpan s (k a b)
 
-
-type ErrDoc = Doc AnsiStyle
 
 data Err = Err
   { span    :: Span

--- a/src/Facet/GHCI.hs
+++ b/src/Facet/GHCI.hs
@@ -27,7 +27,7 @@ import           Data.Semigroup (stimes)
 import           Facet.Algebra (foldCModule, foldCValue, foldSModule)
 import           Facet.Context
 import           Facet.Core (Value)
-import           Facet.Elab as Elab (Err(..), ErrDoc, Reason(..), Type, elabModule)
+import           Facet.Elab as Elab (Err(..), Reason(..), Type, elabModule)
 import           Facet.Name (Index(..), Level(..))
 import           Facet.Parser (Facet(..), module', runFacet, whole)
 import qualified Facet.Pretty as P
@@ -35,6 +35,7 @@ import qualified Facet.Print as P
 import           Facet.Stack (Stack(..))
 import qualified Facet.Surface as S
 import           Facet.Syntax
+import           Prettyprinter (Doc)
 import           Prettyprinter.Render.Terminal (AnsiStyle, Color(..), bold, color)
 import           Silkscreen (annotate, colon, fillSep, flatAlt, group, line, nest, pretty, softline, space, (</>))
 import           Text.Parser.Position (Spanned)
@@ -87,7 +88,7 @@ toNotice lvl src Err{ span, reason, context } =
     -- FIXME: foldl over the context printing each element in the smaller context before it.
 
 
-printReason :: Context (Value ::: Type) -> Reason -> ErrDoc
+printReason :: Context (Value ::: Type) -> Reason -> Doc AnsiStyle
 printReason ctx = group . \case
   FreeVariable n         -> fillSep [P.reflow "variable not in scope:", pretty n]
   CouldNotSynthesize msg -> P.reflow "could not synthesize a type for" <> softline <> P.reflow msg
@@ -109,7 +110,7 @@ printReason ctx = group . \case
   env = elems ctx
 
 
-printType :: Stack P.Print -> Type -> ErrDoc
+printType :: Stack P.Print -> Type -> Doc AnsiStyle
 printType env = P.getPrint . foldCValue P.explicit env
 
 

--- a/src/Facet/GHCI.hs
+++ b/src/Facet/GHCI.hs
@@ -14,9 +14,10 @@ module Facet.GHCI
 ) where
 
 import           Control.Carrier.Lift (runM)
-import           Control.Carrier.Parser.Church (Input(..), ParserC, errToNotice, runParser, runParserWithFile, runParserWithString)
+import           Control.Carrier.Parser.Church as Parse (Err, Input(..), ParserC, errToNotice, runParser, runParserWithFile, runParserWithString)
 import           Control.Carrier.Throw.Either
 import           Control.Effect.Parser.Excerpt (fromSourceAndSpan)
+import           Control.Effect.Parser.Notice (Level(..), Style(..))
 import qualified Control.Effect.Parser.Notice as N
 import           Control.Effect.Parser.Source (Source(..), sourceFromString)
 import           Control.Effect.Parser.Span (Pos(Pos))
@@ -26,7 +27,7 @@ import           Data.Semigroup (stimes)
 import           Facet.Algebra (foldCModule, foldCValue, foldSModule)
 import           Facet.Context
 import           Facet.Core (Value)
-import           Facet.Elab (Err(..), ErrDoc, Reason(..), Type, elabModule)
+import           Facet.Elab as Elab (Err(..), ErrDoc, Reason(..), Type, elabModule)
 import           Facet.Name (Index(..), Level(..))
 import           Facet.Parser (Facet(..), module', runFacet, whole)
 import qualified Facet.Pretty as P
@@ -34,33 +35,34 @@ import qualified Facet.Print as P
 import           Facet.Stack (Stack(..))
 import qualified Facet.Surface as S
 import           Facet.Syntax
-import           Silkscreen (colon, fillSep, flatAlt, group, line, nest, pretty, softline, space, (</>))
+import           Prettyprinter.Render.Terminal (AnsiStyle, Color(..), bold, color)
+import           Silkscreen (annotate, colon, fillSep, flatAlt, group, line, nest, pretty, softline, space, (</>))
 import           Text.Parser.Position (Spanned)
 
 -- Parsing
 
-parseString :: MonadIO m => Facet (ParserC (Either N.Notice)) P.Print -> String -> m ()
-parseString p s = either (P.putDoc . N.prettyNotice) P.prettyPrint (runParserWithString (Pos 0 0) s (runFacet [] p))
+parseString :: MonadIO m => Facet (ParserC (Either (Source, Parse.Err))) P.Print -> String -> m ()
+parseString p s = either (P.putDoc . N.prettyNoticeWith ansiStyle . uncurry errToNotice) P.prettyPrint (runParserWithString (Pos 0 0) s (runFacet [] p))
 
 printFile :: MonadIO m => FilePath -> m ()
 printFile path = runM (runThrow (runParserWithFile path (runFacet [] (whole module')))) >>= \case
-  Left err -> P.putDoc (N.prettyNotice err)
+  Left err -> P.putDoc (N.prettyNoticeWith ansiStyle (uncurry errToNotice err))
   Right m  -> P.prettyPrint (foldSModule P.surface m)
 
-parseFile :: MonadIO m => FilePath -> m (Either N.Notice (Spanned S.Module))
+parseFile :: MonadIO m => FilePath -> m (Either (Source, Parse.Err) (Spanned S.Module))
 parseFile path = runM (runThrow (runParserWithFile path (runFacet [] (whole module'))))
 
 
 -- Elaborating
 
-elabString :: MonadIO m => Facet (ParserC (Either N.Notice)) (Spanned S.Module) -> String -> m ()
+elabString :: MonadIO m => Facet (ParserC (Either (N.Notice AnsiStyle))) (Spanned S.Module) -> String -> m ()
 elabString = elabPathString Nothing
 
 elabFile :: MonadIO m => FilePath -> m ()
 elabFile path = liftIO (readFile path) >>= elabPathString (Just path) module'
 
-elabPathString :: MonadIO m => Maybe FilePath -> Facet (ParserC (Either N.Notice)) (Spanned S.Module) -> String -> m ()
-elabPathString path p s = either (P.putDoc . N.prettyNotice) P.prettyPrint $ do
+elabPathString :: MonadIO m => Maybe FilePath -> Facet (ParserC (Either (N.Notice AnsiStyle))) (Spanned S.Module) -> String -> m ()
+elabPathString path p s = either (P.putDoc . N.prettyNoticeWith ansiStyle) P.prettyPrint $ do
   parsed <- runParser (const Right) failure failure input (runFacet [] (whole p))
   lower $ foldCModule P.explicit <$> elabModule parsed
   where
@@ -69,13 +71,13 @@ elabPathString path p s = either (P.putDoc . N.prettyNotice) P.prettyPrint $ do
   failure = Left . errToNotice src
   mkNotice p = toNotice (Just N.Error) src p
 
-  lower :: Either Err a -> Either N.Notice a
+  lower :: Either Elab.Err a -> Either (N.Notice AnsiStyle) a
   lower = either (throwError . mkNotice) pure
 
 
 -- Errors
 
-toNotice :: Maybe N.Level -> Source -> Err -> N.Notice
+toNotice :: Maybe N.Level -> Source -> Elab.Err -> N.Notice AnsiStyle
 toNotice lvl src Err{ span, reason, context } =
   let reason' = printReason context reason
   in N.Notice lvl (fromSourceAndSpan src span) reason' $
@@ -109,3 +111,16 @@ printReason ctx = group . \case
 
 printType :: Stack P.Print -> Type -> ErrDoc
 printType env = P.getPrint . foldCValue P.explicit env
+
+
+ansiStyle :: Style AnsiStyle
+ansiStyle = Style
+  { pathStyle   = annotate bold
+  , levelStyle  = \case
+    Warn  -> annotate (color Magenta)
+    Error -> annotate (color Red)
+  , posStyle    = annotate bold
+  , gutterStyle = annotate (color Blue)
+  , eofStyle    = annotate (color Blue)
+  , caretStyle  = annotate (color Green)
+  }

--- a/src/Facet/Pretty.hs
+++ b/src/Facet/Pretty.hs
@@ -34,7 +34,7 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TLB
 import           Facet.Stack
 import qualified Prettyprinter as PP
-import qualified Prettyprinter.Render.Terminal as ANSI
+import qualified Prettyprinter.Render.Terminal as PP
 import qualified Prettyprinter.Render.Terminal.Internal as PPI
 import           Silkscreen hiding (column, width)
 import qualified System.Console.ANSI as ANSI
@@ -48,18 +48,18 @@ layoutOptionsForTerminal = do
   s <- maybe 80 Size.width <$> Size.size
   pure PP.defaultLayoutOptions{ PP.layoutPageWidth = PP.AvailablePerLine s 0.8 }
 
-hPutDoc :: MonadIO m => Handle -> PP.Doc ANSI.AnsiStyle -> m ()
+hPutDoc :: MonadIO m => Handle -> PP.Doc PP.AnsiStyle -> m ()
 hPutDoc handle doc = liftIO $ do
   opts <- layoutOptionsForTerminal
-  ANSI.renderIO handle (PP.layoutSmart opts (doc <> PP.line))
+  PP.renderIO handle (PP.layoutSmart opts (doc <> PP.line))
 
-hPutDocWith :: MonadIO m => Handle -> (a -> ANSI.AnsiStyle) -> PP.Doc a -> m ()
+hPutDocWith :: MonadIO m => Handle -> (a -> PP.AnsiStyle) -> PP.Doc a -> m ()
 hPutDocWith handle style = hPutDoc handle . PP.reAnnotate style
 
-putDoc :: MonadIO m => PP.Doc ANSI.AnsiStyle -> m ()
+putDoc :: MonadIO m => PP.Doc PP.AnsiStyle -> m ()
 putDoc = hPutDoc stdout
 
-putDocWith :: MonadIO m => (a -> ANSI.AnsiStyle) -> PP.Doc a -> m ()
+putDocWith :: MonadIO m => (a -> PP.AnsiStyle) -> PP.Doc a -> m ()
 putDocWith = hPutDocWith stdout
 
 

--- a/src/Facet/Pretty.hs
+++ b/src/Facet/Pretty.hs
@@ -151,7 +151,7 @@ renderIO h stream = do
             newStyle <- unsafePeek
             sendM $ ANSI.setSGR newStyle
             go rest
-  liftIO $ runM $ evalState (Nil :: Stack [ANSI.SGR]) $ go stream
+  liftIO $ runM $ evalState (Nil :> ([] :: [ANSI.SGR])) $ go stream
   where
   push x = modify (:>x)
   unsafePeek = do
@@ -187,4 +187,4 @@ renderLazy =
                 newStyle = unsafePeek s'
             in  TLB.fromText (T.pack (ANSI.setSGRCode newStyle)) <> go s' rest
 
-  in TLB.toLazyText . go Nil
+  in TLB.toLazyText . go (Nil :> [])

--- a/src/Facet/Pretty.hs
+++ b/src/Facet/Pretty.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 module Facet.Pretty
 ( -- * Output
   layoutOptionsForTerminal
@@ -14,15 +16,23 @@ module Facet.Pretty
 , varFrom
   -- * Columnar layout
 , tabulate2
+  -- * Rendering
+, renderIO
 ) where
 
+import           Control.Carrier.Lift
+import           Control.Carrier.State.Church
 import           Control.Monad.IO.Class
 import           Data.Bifunctor (first)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import           Facet.Stack
 import qualified Prettyprinter as PP
 import qualified Prettyprinter.Render.Terminal as ANSI
 import           Silkscreen hiding (column, width)
+import qualified System.Console.ANSI as ANSI
 import qualified System.Console.Terminal.Size as Size
-import           System.IO (Handle, stdout)
+import           System.IO (Handle, hPutChar, stdout)
 
 -- Output
 
@@ -84,3 +94,43 @@ data Column a = Column { width :: Int, doc :: PP.Doc a }
 
 column :: PP.Doc a -> Column a
 column a = Column (length (show (PP.unAnnotate a))) a
+
+
+-- Rendering
+
+-- | Render a 'PP.SimpleDocStream' to a 'Handle' using 'ANSI.SGR' codes as the annotation type.
+renderIO :: MonadIO m => Handle -> PP.SimpleDocStream [ANSI.SGR] -> m ()
+renderIO h stream = do
+  let go = \case
+        PP.SFail -> error "fail"
+        PP.SEmpty -> pure ()
+        PP.SChar c rest -> do
+            sendM $ hPutChar h c
+            go rest
+        PP.SText _ t rest -> do
+            sendM $ T.hPutStr h t
+            go rest
+        PP.SLine i rest -> do
+            sendM $ hPutChar h '\n'
+            sendM $ T.hPutStr h (T.replicate i (T.singleton ' '))
+            go rest
+        PP.SAnnPush style rest -> do
+            currentStyle <- unsafePeek
+            let newStyle = style <> currentStyle
+            push newStyle
+            sendM $ ANSI.setSGR newStyle
+            go rest
+        PP.SAnnPop rest -> do
+            _currentStyle <- unsafePop
+            newStyle <- unsafePeek
+            sendM $ ANSI.setSGR newStyle
+            go rest
+  liftIO $ runM $ evalState (Nil :: Stack [ANSI.SGR]) $ go stream
+  where
+  push x = modify (:>x)
+  unsafePeek = do
+    _ :> l <- get
+    pure l
+  unsafePop = do
+    i :> _ <- get
+    put (i :: Stack [ANSI.SGR])

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -68,7 +68,7 @@ terminalStyle = \case
   where
   setRGB = ANSI.SetRGBColor ANSI.Foreground
   bold = ANSI.SetConsoleIntensity ANSI.BoldIntensity
-  pick i s l = uncurryRGB sRGB (hsl (fromIntegral i * phi * 36) s l)
+  pick i s l = uncurryRGB sRGB (hsl (fromIntegral i * phi * 30) s l)
   phi = 1.618033988749895
 
 

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -57,7 +57,7 @@ getPrint' = runRainbow (annotate . Nest) 0 . runPrec Null . doc . group
 
 terminalStyle :: Highlight -> [ANSI.SGR]
 terminalStyle = \case
-  Nest i -> [setRGB (pick i 0.5 0.6)]
+  Nest i -> [setRGB (pick i 0.4 0.8)]
   Name i -> [setRGB (pick (-getLevel i) 0.8 0.6)]
   Op     -> [setRGB cyan]
   Type   -> [setRGB yellow]

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -63,7 +63,7 @@ terminalStyle = \case
   Type   -> [setRGB yellow]
   Con    -> [setRGB red]
   Lit    -> [bold]
-  Hole m -> [bold, setRGB (pick (-getMeta m) 0.7 0.3)]
+  Hole m -> [bold, setRGB (pick (-getMeta m) 0.5 0.45)]
   ANSI s -> s
   where
   setRGB = ANSI.SetRGBColor ANSI.Foreground

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -54,16 +54,16 @@ getPrint' = runRainbow (annotate . Nest) 0 . runPrec Null . doc . group
 
 terminalStyle :: Highlight -> [ANSI.SGR]
 terminalStyle = \case
-  Nest i -> colours !! (i `mod` len)
-  Name i -> reverse colours !! (getLevel i `mod` len)
+  Nest i -> [colours !! (i `mod` len)]
+  Name i -> [reverse colours !! (getLevel i `mod` len)]
   Op     -> [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Cyan]
   Type   -> [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Yellow]
   Con    -> [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
   Lit    -> [ANSI.SetConsoleIntensity ANSI.BoldIntensity]
-  Hole m -> ANSI.SetConsoleIntensity ANSI.BoldIntensity : reverse colours !! (getMeta m `mod` len)
+  Hole m -> ANSI.SetConsoleIntensity ANSI.BoldIntensity : [reverse colours !! (getMeta m `mod` len)]
   ANSI s -> s
   where
-  colours = pure $
+  colours =
     [ ANSI.Red
     , ANSI.Green
     , ANSI.Yellow

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -26,6 +26,10 @@ module Facet.Print
 
 import           Control.Applicative ((<**>))
 import           Control.Monad.IO.Class
+import           Data.Colour.Names
+import           Data.Colour.RGBSpace
+import           Data.Colour.RGBSpace.HSL
+import           Data.Colour.SRGB
 import           Data.Foldable (foldl', toList)
 import           Data.Function (on)
 import           Data.List (intersperse)
@@ -56,13 +60,14 @@ terminalStyle :: Highlight -> [ANSI.SGR]
 terminalStyle = \case
   Nest i -> [colours !! (i `mod` len)]
   Name i -> [reverse colours !! (getLevel i `mod` len)]
-  Op     -> [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Cyan]
-  Type   -> [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Yellow]
-  Con    -> [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
+  Op     -> [setRGB cyan]
+  Type   -> [setRGB yellow]
+  Con    -> [setRGB red]
   Lit    -> [ANSI.SetConsoleIntensity ANSI.BoldIntensity]
   Hole m -> ANSI.SetConsoleIntensity ANSI.BoldIntensity : [reverse colours !! (getMeta m `mod` len)]
   ANSI s -> s
   where
+  setRGB = ANSI.SetRGBColor ANSI.Foreground
   colours =
     [ ANSI.Red
     , ANSI.Green

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -63,11 +63,12 @@ terminalStyle = \case
   Op     -> [setRGB cyan]
   Type   -> [setRGB yellow]
   Con    -> [setRGB red]
-  Lit    -> [ANSI.SetConsoleIntensity ANSI.BoldIntensity]
-  Hole m -> ANSI.SetConsoleIntensity ANSI.BoldIntensity : [reverse colours !! (getMeta m `mod` len)]
+  Lit    -> [bold]
+  Hole m -> [bold, reverse colours !! (getMeta m `mod` len)]
   ANSI s -> s
   where
   setRGB = ANSI.SetRGBColor ANSI.Foreground
+  bold = ANSI.SetConsoleIntensity ANSI.BoldIntensity
   colours =
     [ ANSI.Red
     , ANSI.Green

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -24,7 +24,6 @@ module Facet.Print
 , explicit
 ) where
 
-import           Control.Applicative ((<**>))
 import           Control.Monad.IO.Class
 import           Data.Colour.Names
 import           Data.Colour.RGBSpace
@@ -58,28 +57,19 @@ getPrint' = runRainbow (annotate . Nest) 0 . runPrec Null . doc . group
 
 terminalStyle :: Highlight -> [ANSI.SGR]
 terminalStyle = \case
-  Nest i -> [colours !! (i `mod` len)]
-  Name i -> [reverse colours !! (getLevel i `mod` len)]
+  Nest i -> [setRGB (pick i 0.5 0.6)]
+  Name i -> [setRGB (pick (-getLevel i) 0.8 0.6)]
   Op     -> [setRGB cyan]
   Type   -> [setRGB yellow]
   Con    -> [setRGB red]
   Lit    -> [bold]
-  Hole m -> [bold, reverse colours !! (getMeta m `mod` len)]
+  Hole m -> [bold, setRGB (pick (-getMeta m) 0.7 0.3)]
   ANSI s -> s
   where
   setRGB = ANSI.SetRGBColor ANSI.Foreground
   bold = ANSI.SetConsoleIntensity ANSI.BoldIntensity
-  colours =
-    [ ANSI.Red
-    , ANSI.Green
-    , ANSI.Yellow
-    , ANSI.Blue
-    , ANSI.Magenta
-    , ANSI.Cyan
-    ]
-    <**>
-    [ANSI.SetColor ANSI.Foreground ANSI.Vivid, ANSI.SetColor ANSI.Foreground ANSI.Dull]
-  len = length colours
+  pick i s l = uncurryRGB sRGB (hsl (fromIntegral i * phi * 36) s l)
+  phi = 1.618033988749895
 
 
 data Print = Print { fvs :: FVs, doc :: Prec Precedence (Rainbow (PP.Doc Highlight)) }

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 module Facet.REPL
 ( repl
 ) where
@@ -9,12 +10,12 @@ import           Control.Applicative ((<|>))
 import           Control.Carrier.Empty.Church
 import           Control.Carrier.Error.Church
 import           Control.Carrier.Fresh.Church
-import           Control.Carrier.Parser.Church
+import           Control.Carrier.Parser.Church hiding (runParserWith, runParserWithFile, runParserWithString)
 import           Control.Carrier.Readline.Haskeline
 import           Control.Carrier.State.Church
 import           Control.Effect.Lens (use, (%=))
-import           Control.Effect.Parser.Notice (Level(..), Style(..), prettyNoticeWith)
-import           Control.Effect.Parser.Source (Source(..))
+import           Control.Effect.Parser.Notice (Level(..), Notice, Style(..), prettyNoticeWith)
+import           Control.Effect.Parser.Source (sourceFromString)
 import           Control.Effect.Parser.Span (Pos(..))
 import           Control.Lens (Lens', lens)
 import           Control.Monad.IO.Class
@@ -25,14 +26,14 @@ import           Data.Semigroup
 import           Data.Text.Lazy (unpack)
 import           Facet.Algebra
 import           Facet.Parser
-import           Facet.Pretty hiding (renderLazy)
+import           Facet.Pretty
 import           Facet.Print
 import           Facet.REPL.Parser
 import           Facet.Stack
 import           Facet.Surface (Expr, Type)
 import           Prelude hiding (print)
 import           Prettyprinter as P hiding (column, width)
-import           Prettyprinter.Render.Terminal (AnsiStyle, Color(..), bold, color, renderLazy)
+import qualified System.Console.ANSI as ANSI
 import           Text.Parser.Char hiding (space)
 import           Text.Parser.Combinators
 import           Text.Parser.Position
@@ -68,7 +69,7 @@ files_ = lens files (\ r files -> r{ files })
 loop :: (Has Empty sig m, Has Fresh sig m, Has Readline sig m, Has (State REPL) sig m, MonadIO m) => m ()
 loop = do
   (line, resp) <- prompt
-  runError (print . prettyNoticeWith ansiStyle . uncurry errToNotice) pure $ case resp of
+  runError (print . prettyNoticeWith sgrStyle) pure $ case resp of
     -- FIXME: evaluate expressions
     Just resp -> runParserWithString (Pos line 0) resp (runFacet [] (whole commandParser)) >>= runAction
     Nothing   -> pure ()
@@ -115,22 +116,22 @@ data Action
   | Type (Spanned Expr)
   | Kind (Spanned Type)
 
-load :: (Has (Error (Source, Err)) sig m, Has Readline sig m, Has (State REPL) sig m, MonadIO m) => FilePath -> m ()
+load :: (Has (Error (Notice [ANSI.SGR])) sig m, Has Readline sig m, Has (State REPL) sig m, MonadIO m) => FilePath -> m ()
 load path = do
   files_ %= Map.insert path File{ loaded = False }
   runParserWithFile path (runFacet [] (whole module')) >>= print . getPrint . foldSModule surface
 
-reload :: (Has (Error (Source, Err)) sig m, Has Readline sig m, Has (State REPL) sig m, MonadIO m) => m ()
+reload :: (Has (Error (Notice [ANSI.SGR])) sig m, Has Readline sig m, Has (State REPL) sig m, MonadIO m) => m ()
 reload = do
   files <- use files_
   -- FIXME: topological sort
   let ln = length files
   for_ (zip [(1 :: Int)..] (Map.keys files)) $ \ (i, path) -> do
     -- FIXME: module name
-    print $ annotate (color Green) (brackets (pretty i <+> pretty "of" <+> pretty ln)) <+> nest 2 (group (fillSep [ pretty "Loading", pretty path ]))
-    (runParserWithFile path (runFacet [] (whole module')) >>= print . getPrint . foldSModule surface) `catchError` \ n -> print (indent 2 (prettyNoticeWith ansiStyle (uncurry errToNotice n)))
+    print $ annotate [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Green] (brackets (pretty i <+> pretty "of" <+> pretty ln)) <+> nest 2 (group (fillSep [ pretty "Loading", pretty path ]))
+    (runParserWithFile path (runFacet [] (whole module')) >>= print . getPrint . foldSModule surface) `catchError` \ n -> print (indent 2 (prettyNoticeWith sgrStyle n))
 
-helpDoc :: Doc AnsiStyle
+helpDoc :: Doc [ANSI.SGR]
 helpDoc = tabulate2 (stimes (3 :: Int) P.space) entries
   where
   entries = map entry commands
@@ -145,20 +146,39 @@ prompt = do
   p <- liftIO $ fn line
   (,) line <$> getInputLine p
 
-print :: (Has Readline sig m, MonadIO m) => Doc AnsiStyle -> m ()
+print :: (Has Readline sig m, MonadIO m) => Doc [ANSI.SGR] -> m ()
 print d = do
   opts <- liftIO layoutOptionsForTerminal
   outputStrLn (unpack (renderLazy (layoutSmart opts d)))
 
 
-ansiStyle :: Style AnsiStyle
-ansiStyle = Style
-  { pathStyle   = annotate bold
+sgrStyle :: Style [ANSI.SGR]
+sgrStyle = Style
+  { pathStyle   = annotate [ANSI.SetConsoleIntensity ANSI.BoldIntensity]
   , levelStyle  = \case
-    Warn  -> annotate (color Magenta)
-    Error -> annotate (color Red)
-  , posStyle    = annotate bold
-  , gutterStyle = annotate (color Blue)
-  , eofStyle    = annotate (color Blue)
-  , caretStyle  = annotate (color Green)
+    Warn  -> annotate [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Magenta]
+    Error -> annotate [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
+  , posStyle    = annotate [ANSI.SetConsoleIntensity ANSI.BoldIntensity]
+  , gutterStyle = annotate [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
+  , eofStyle    = annotate [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
+  , caretStyle  = annotate [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Green]
   }
+
+
+
+runParserWithString :: Has (Throw (Notice [ANSI.SGR])) sig m => Pos -> String -> ParserC m a -> m a
+runParserWithString pos str = runParserWith Nothing (Input pos str)
+{-# INLINE runParserWithString #-}
+
+runParserWithFile :: (Has (Throw (Notice [ANSI.SGR])) sig m, MonadIO m) => FilePath -> ParserC m a -> m a
+runParserWithFile path p = do
+  input <- liftIO (readFile path)
+  runParserWith (Just path) (Input (Pos 0 0) input) p
+{-# INLINE runParserWithFile #-}
+
+runParserWith :: Has (Throw (Notice [ANSI.SGR])) sig m => Maybe FilePath -> Input -> ParserC m a -> m a
+runParserWith path input = runParser (const pure) failure failure input
+  where
+  src = sourceFromString path (str input)
+  failure = throwError @(Notice [ANSI.SGR]) . errToNotice src
+{-# INLINE runParserWith #-}


### PR DESCRIPTION
This PR migrates away from `prettyprinter-ansi-terminal` onto direct usage of `ansi-terminal`: annotations destined for the terminal are now `[SGR]`.