### PR TITLE
Default extensions

### DIFF
--- a/facet.cabal
+++ b/facet.cabal
@@ -90,7 +90,7 @@ library
     , these
     , transformers
     , unordered-containers
-  hs-source-dirs:      src
+  hs-source-dirs: src
 
 
 test-suite test

--- a/facet.cabal
+++ b/facet.cabal
@@ -33,6 +33,23 @@ common common
     ghc-options:
       -Wno-missing-safe-haskell-mode
       -Wno-prepositive-qualified-module
+  default-extensions:
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    DisambiguateRecordFields
+    DuplicateRecordFields
+    FlexibleContexts
+    FlexibleInstances
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    MultiParamTypeClasses
+    MultiWayIf
+    NamedFieldPuns
+    RankNTypes
+    TupleSections
+    TypeApplications
+    TypeOperators
 
 library
   import: common

--- a/script/ghci-flags
+++ b/script/ghci-flags
@@ -68,6 +68,23 @@ function flags {
   echo "-Wno-unsafe"
   [[ "$ghc_version" = 8.8.* ]] || [[ "$ghc_version" = 8.10.* ]] && echo "-Wno-missing-deriving-strategies" || true
   [[ "$ghc_version" = 8.10.* ]] && echo "-Wno-missing-safe-haskell-mode" && echo "-Wno-prepositive-qualified-module" && echo "-Wno-unused-packages"
+
+  echo "-XDeriveTraversable"
+  echo "-XDerivingStrategies"
+  echo "-XDerivingVia"
+  echo "-XDisambiguateRecordFields"
+  echo "-XDuplicateRecordFields"
+  echo "-XFlexibleContexts"
+  echo "-XFlexibleInstances"
+  echo "-XGeneralizedNewtypeDeriving"
+  echo "-XLambdaCase"
+  echo "-XMultiParamTypeClasses"
+  echo "-XMultiWayIf"
+  echo "-XNamedFieldPuns"
+  echo "-XRankNTypes"
+  echo "-XTupleSections"
+  echo "-XTypeApplications"
+  echo "-XTypeOperators"
 }
 
 flags > "$output_file"

--- a/src/Facet/Algebra.hs
+++ b/src/Facet/Algebra.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.Algebra
 ( -- * Folds
   Var(..)

--- a/src/Facet/Carrier/Error/Lens.hs
+++ b/src/Facet/Carrier/Error/Lens.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Facet.Carrier.Error.Lens
 ( -- * Error carrier

--- a/src/Facet/Carrier/Parser/Church.hs
+++ b/src/Facet/Carrier/Parser/Church.hs
@@ -1,13 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Facet.Carrier.Parser.Church
 ( -- * Parser carrier

--- a/src/Facet/Carrier/State/Lens.hs
+++ b/src/Facet/Carrier/State/Lens.hs
@@ -1,8 +1,4 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Facet.Carrier.State.Lens
 ( -- * State carrier

--- a/src/Facet/Carrier/Throw/Inject.hs
+++ b/src/Facet/Carrier/Throw/Inject.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Facet.Carrier.Throw.Inject
 ( -- * Throw carrier

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.Context
 ( -- * Contexts
   Context(..)

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.Core
 ( -- * Values
   Value(..)

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE UndecidableInstances #-}
 module Facet.Elab
 ( Type
 , Expr

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -1,15 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Facet.Elab
 ( Type

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.Env
 ( Env(..)
 , fromList

--- a/src/Facet/Eval.hs
+++ b/src/Facet/Eval.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeApplications #-}
 module Facet.Eval
 ( eval
 ) where

--- a/src/Facet/GHCI.hs
+++ b/src/Facet/GHCI.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.GHCI
 ( -- * Parsing
   parseString

--- a/src/Facet/Name.hs
+++ b/src/Facet/Name.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
 module Facet.Name
 ( UName(..)
 , Index(..)

--- a/src/Facet/Notice.hs
+++ b/src/Facet/Notice.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 module Facet.Notice
 ( -- * Notices
   Level(..)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.Notice.Elab
 ( -- * Notices
   Notice(..)

--- a/src/Facet/Notice/Parser.hs
+++ b/src/Facet/Notice/Parser.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 module Facet.Notice.Parser
 ( -- * Notices
   Notice(..)

--- a/src/Facet/Parser.hs
+++ b/src/Facet/Parser.hs
@@ -1,10 +1,3 @@
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.Parser
 ( runFacet
 , Facet(..)

--- a/src/Facet/Pretty.hs
+++ b/src/Facet/Pretty.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 module Facet.Pretty
 ( -- * Output
   layoutOptionsForTerminal

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -1,17 +1,4 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 module Facet.Print
 ( prettyPrint
 , getPrint

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeApplications #-}
 module Facet.REPL
 ( repl
 ) where

--- a/src/Facet/REPL/Parser.hs
+++ b/src/Facet/REPL/Parser.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE RankNTypes #-}
 module Facet.REPL.Parser
 ( Command(..)
 , meta

--- a/src/Facet/Source.hs
+++ b/src/Facet/Source.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 module Facet.Source
 ( Source(..)
 , path_

--- a/src/Facet/Stack.hs
+++ b/src/Facet/Stack.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE LambdaCase #-}
 -- | Really just a snoc list, but the shoe fits if you squish things up just right.
 module Facet.Stack
 ( Stack(..)

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.Surface
 ( -- * Expressions
   Expr(..)

--- a/src/Facet/Syntax.hs
+++ b/src/Facet/Syntax.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeOperators #-}
 module Facet.Syntax
 ( (:::)(..)
 , tm

--- a/test/Facet/Carrier/Parser/Church/Test.hs
+++ b/test/Facet/Carrier/Parser/Church/Test.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Facet.Carrier.Parser.Church.Test
 ( tests

--- a/test/Facet/Source/Test.hs
+++ b/test/Facet/Source/Test.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Facet.Source.Test
 ( tests


### PR DESCRIPTION
This PR uses the `default-extensions` field to eliminate a bunch of the file-by-file extensions. I don’t normally do this sort of thing, because it can break tooling, but tooling is better than ever now and so I’m taking it for a spin.

Dedicated to @lexi-lambda, @mbbx6spp, & @chshersh 😅